### PR TITLE
chore: derive Ord for QuorumType

### DIFF
--- a/json/src/lib.rs
+++ b/json/src/lib.rs
@@ -2486,7 +2486,7 @@ pub struct BLS {
 
 // --------------------------- Quorum -------------------------------
 
-#[derive(Clone, Copy, PartialEq, Eq, Debug, Serialize_repr, Hash, Encode, Decode)]
+#[derive(Clone, Copy, PartialEq, Eq, Debug, Serialize_repr, Hash, Encode, Decode, Ord, PartialOrd)]
 #[repr(u8)]
 pub enum QuorumType {
     Llmq50_60 = 1,


### PR DESCRIPTION
We use QuorumType as a key in BTreeMap in Drive so we need Ord trait to be implemented