### PR TITLE
fix: incorrect get_transaction_are_locked rpc call name

### DIFF
--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -475,13 +475,13 @@ pub trait RpcApi: Sized {
     fn get_transaction_are_locked(
         &self,
         tx_ids: &Vec<dashcore::Txid>,
-    ) -> Result<Vec<json::GetTransactionLockedResult>> {
+    ) -> Result<Vec<Option<json::GetTransactionLockedResult>>> {
         let transaction_ids_json = tx_ids
             .into_iter()
             .map(|tx_id| Ok(into_json(tx_id)?))
             .collect::<Result<Vec<Value>>>()?;
         let args = [transaction_ids_json.into()];
-        self.call("gettransactionsarelocked", &args)
+        self.call("gettxchainlock", &args)
     }
 
     fn list_transactions(

--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -481,7 +481,7 @@ pub trait RpcApi: Sized {
             .map(|tx_id| Ok(into_json(tx_id)?))
             .collect::<Result<Vec<Value>>>()?;
         let args = [transaction_ids_json.into()];
-        self.call("gettxchainlock", &args)
+        self.call("gettxchainlocks", &args)
     }
 
     fn list_transactions(

--- a/json/src/lib.rs
+++ b/json/src/lib.rs
@@ -702,8 +702,7 @@ pub struct WalletTxInfo {
 #[derive(Clone, PartialEq, Eq, Debug, Deserialize)]
 pub struct GetTransactionLockedResult {
     pub height: i32,
-    #[serde(rename = "chainlock")]
-    pub chain_lock: bool,
+    pub chainlock: bool,
     pub mempool: bool,
 }
 

--- a/json/src/lib.rs
+++ b/json/src/lib.rs
@@ -701,8 +701,7 @@ pub struct WalletTxInfo {
 
 #[derive(Clone, PartialEq, Eq, Debug, Deserialize)]
 pub struct GetTransactionLockedResult {
-    #[serde(default, deserialize_with = "deserialize_u32_opt")]
-    pub height: Option<u32>,
+    pub height: i32,
     #[serde(rename = "chainlock")]
     pub chain_lock: bool,
 }

--- a/json/src/lib.rs
+++ b/json/src/lib.rs
@@ -704,6 +704,7 @@ pub struct GetTransactionLockedResult {
     pub height: i32,
     #[serde(rename = "chainlock")]
     pub chain_lock: bool,
+    pub mempool: bool,
 }
 
 #[derive(Clone, PartialEq, Eq, Debug, Deserialize)]


### PR DESCRIPTION
Fixes name and response shape of the `gettxchainlocks` RPC endpoint 