### PR TITLE
feat: add single node quorum type

### DIFF
--- a/integration_test/Cargo.toml
+++ b/integration_test/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 
 [dependencies]
 dashcore-rpc = { path = "../client" }
-lazy_static = "1.4.0"
+lazy_static = "^1.5.0"
 log = "0.4"
 hex = "0.4.3"
 dotenvy = "0.15.7"

--- a/integration_test/Cargo.toml
+++ b/integration_test/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 
 [dependencies]
 dashcore-rpc = { path = "../client" }
-lazy_static = "^1.5.0"
+lazy_static = "1.4.0"
 log = "0.4"
 hex = "0.4.3"
 dotenvy = "0.15.7"

--- a/json/src/lib.rs
+++ b/json/src/lib.rs
@@ -2469,6 +2469,7 @@ pub enum QuorumType {
     LlmqDevnetDip0024 = 105,
     LlmqTestPlatform = 106,
     LlmqDevnetPlatform = 107,
+    LlmqSingleNode = 111,
     UNKNOWN = 0,
 }
 
@@ -2489,6 +2490,7 @@ impl From<u32> for QuorumType {
             105 => QuorumType::LlmqDevnetDip0024,
             106 => QuorumType::LlmqTestPlatform,
             107 => QuorumType::LlmqDevnetPlatform,
+            111 => QuorumType::LlmqSingleNode,
             _ => QuorumType::UNKNOWN,
         }
     }
@@ -2512,6 +2514,7 @@ impl Display for QuorumType {
             QuorumType::UNKNOWN => "unknown",
             QuorumType::LlmqTestPlatform => "llmq_test_platform",
             QuorumType::LlmqDevnetPlatform => "llmq_devnet_platform",
+            QuorumType::LlmqSingleNode => "llmq_1_100",
         };
         write!(f, "{}", value)
     }
@@ -2534,6 +2537,7 @@ impl From<&str> for QuorumType {
             "llmq_devnet_dip0024" => QuorumType::LlmqDevnetDip0024,
             "llmq_test_platform" => QuorumType::LlmqTestPlatform,
             "llmq_devnet_platform" => QuorumType::LlmqDevnetPlatform,
+            "llmq_1_100" => QuorumType::LlmqSingleNode,
             _ => QuorumType::UNKNOWN,
         }
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a new quorum type `LlmqSingleNode` to the system, expanding the existing enum capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->