### PR TITLE
chore: bump version to 0.16

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,3 +5,6 @@ members = [
     "client",
     "integration_test",
 ]
+
+[workspace.package]
+version = "0.16.0"

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dashcore-rpc"
-version = "0.15.13"
+version = { workspace = true }
 authors = [
     "Steven Roose <steven@stevenroose.org>",
     "Jean Pierre Dudey <jeandudey@hotmail.com>",
@@ -19,15 +19,13 @@ name = "dashcore_rpc"
 path = "src/lib.rs"
 
 [dependencies]
-dashcore-rpc-json = { version = "0.15", path = "../json" }
+dashcore-rpc-json = { version = "0.16", path = "../json" }
 
 log = "0.4.5"
-env_logger = "0.10.0"
 jsonrpc = "0.14.0"
 
 # Used for deserialization of JSON.
 serde = { version = "1.0.132", features = ["derive"] }
 serde_json = { version="1.0", features=["preserve_order"] }
 
-dashcore-private = { git="https://github.com/dashpay/rust-dashcore.git", tag = "0.34.0" }
 hex = { version="0.4", features=["serde"]}

--- a/integration_test/Cargo.toml
+++ b/integration_test/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "integration_test"
-version = "0.1.0"
 authors = ["Steven Roose <steven@stevenroose.org>"]
 edition = "2021"
+publish = false
 
 [dependencies]
 dashcore-rpc = { path = "../client" }

--- a/json/Cargo.toml
+++ b/json/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dashcore-rpc-json"
-version = "0.15.13"
+version = { workspace = true }
 authors = [
     "Steven Roose <steven@stevenroose.org>",
     "Jean Pierre Dudey <jeandudey@hotmail.com>",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Workspace Configuration**
	- Updated package versioning to use workspace configuration across multiple Cargo.toml files
	- Set workspace package version to 0.16.0
	- Marked integration test package as non-publishable

- **Dependency Updates**
	- Updated `dashcore-rpc-json` dependency to version 0.16
	- Removed `dashcore-private` dependency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->