### PR TITLE
Bloch hash for `get_protx_info` and public `mn_type`

### DIFF
--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -1389,7 +1389,7 @@ pub trait RpcApi: Sized {
 
     /// Returns a returns detailed information about a deterministic masternode
     fn get_protx_info(&self, protx_hash: &ProTxHash, block_hash: Option<&BlockHash>) -> Result<json::ProTxInfo> {
-        let mut args = ["info".into(), into_json(protx_hash)?, opt_into_json(block_hash)?];
+        let mut args = ["info".into(), into_json(protx_hash.to_hex())?, opt_into_json(block_hash)?];
 
         self.call::<json::ProTxInfo>("protx", handle_defaults(&mut args, &[null()]))
     }

--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -1389,16 +1389,9 @@ pub trait RpcApi: Sized {
 
     /// Returns a returns detailed information about a deterministic masternode
     fn get_protx_info(&self, protx_hash: &ProTxHash, block_hash: Option<&BlockHash>) -> Result<ProTxInfo> {
-        let mut args = Vec::new();
+        let mut args = ["info".into(), into_json(protx_hash)?, opt_into_json(block_hash)?];
 
-        args.push("info".into());
-        args.push(into_json(protx_hash)?);
-
-        if !block_hash.is_none() {
-            args.push(into_json(block_hash.unwrap())?)
-        }
-
-        self.call::<ProTxInfo>("protx", handle_defaults(&mut args, &[null()]))
+        self.call::<ProTxInfo>("protx", handle_defaults(&mut args, &[null(), null()]))
     }
 
     /// Returns a list of provider transactions

--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -1388,10 +1388,10 @@ pub trait RpcApi: Sized {
     }
 
     /// Returns a returns detailed information about a deterministic masternode
-    fn get_protx_info(&self, protx_hash: &ProTxHash, block_hash: Option<&BlockHash>) -> Result<ProTxInfo> {
+    fn get_protx_info(&self, protx_hash: &ProTxHash, block_hash: Option<&BlockHash>) -> Result<json::ProTxInfo> {
         let mut args = ["info".into(), into_json(protx_hash)?, opt_into_json(block_hash)?];
 
-        self.call::<ProTxInfo>("protx", handle_defaults(&mut args, &[null()]))
+        self.call::<json::ProTxInfo>("protx", handle_defaults(&mut args, &[null()]))
     }
 
     /// Returns a list of provider transactions

--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -1388,8 +1388,16 @@ pub trait RpcApi: Sized {
     }
 
     /// Returns a returns detailed information about a deterministic masternode
-    fn get_protx_info(&self, protx_hash: &ProTxHash) -> Result<ProTxInfo> {
-        let mut args = ["info".into(), into_json(protx_hash)?];
+    fn get_protx_info(&self, protx_hash: &ProTxHash, block_hash: Option<&BlockHash>) -> Result<ProTxInfo> {
+        let mut args = Vec::new();
+
+        args.push("info".into());
+        args.push(into_json(protx_hash)?);
+
+        if !block_hash.is_none() {
+            args.push(into_json(block_hash.unwrap())?)
+        }
+
         self.call::<ProTxInfo>("protx", handle_defaults(&mut args, &[null()]))
     }
 

--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -1391,7 +1391,7 @@ pub trait RpcApi: Sized {
     fn get_protx_info(&self, protx_hash: &ProTxHash, block_hash: Option<&BlockHash>) -> Result<ProTxInfo> {
         let mut args = ["info".into(), into_json(protx_hash)?, opt_into_json(block_hash)?];
 
-        self.call::<ProTxInfo>("protx", handle_defaults(&mut args, &[null(), null()]))
+        self.call::<ProTxInfo>("protx", handle_defaults(&mut args, &[null()]))
     }
 
     /// Returns a list of provider transactions

--- a/json/src/lib.rs
+++ b/json/src/lib.rs
@@ -3007,7 +3007,7 @@ pub struct MetaInfo {
 #[serde(rename_all = "camelCase")]
 pub struct ProTxInfo {
     #[serde(rename = "type")]
-    mn_type: Option<String>,
+    pub mn_type: Option<String>,
     #[serde(rename = "proTxHash")]
     pub pro_tx_hash: ProTxHash,
     #[serde(with = "hex")]


### PR DESCRIPTION
# Issue
For new data in indexer, we need to check where mn vote form `Evo` and where from `Regular` node. For this task we use `get_protx_info` method, which contains field `type` in response, but he always returns 404 and don't allow optional block hash in rust implementation.

# Things done
* Added pub modifier for `mn_type` in struct
* Fixed 404 not found by adding `to_hex` before call
* Added optional `block_hash`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced masternode detail retrieval with optional support for a block identifier, allowing more specific queries.
	- Enabled public access to masternode type information, providing a comprehensive view of masternode characteristics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->