### PR TITLE
feat: new getislocks rpc

### DIFF
--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -446,12 +446,12 @@ pub trait RpcApi: Sized {
         Ok(dashcore::consensus::encode::deserialize(&bytes)?)
     }
 
-    fn get_raw_instant_locks(
+    fn get_instant_locks(
         &self,
         txids: Vec<&dashcore::Txid>,
     ) -> Result<Vec<String>> {
         let mut args = [into_json(txids)?];
-        let instant_locks: Vec<String> = self.call("getrawislocks", handle_defaults(&mut args, &[null()]))?;
+        let instant_locks: Vec<String> = self.call("getislocks", handle_defaults(&mut args, &[null()]))?;
         Ok(instant_locks)
     }
 

--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -446,6 +446,15 @@ pub trait RpcApi: Sized {
         Ok(dashcore::consensus::encode::deserialize(&bytes)?)
     }
 
+    fn get_raw_instant_locks(
+        &self,
+        txids: Vec<&dashcore::Txid>,
+    ) -> Result<Vec<String>> {
+        let mut args = [into_json(txids)?];
+        let instant_locks: Vec<String> = self.call("getrawislocks", handle_defaults(&mut args, &[null()]))?;
+        Ok(instant_locks)
+    }
+
     fn get_raw_transaction_multi(
         &self,
         transactions_by_block_hash: BTreeMap<&BlockHash, Vec<&dashcore::Txid>>,


### PR DESCRIPTION
# Issue

In Dash Core 0.22.1 there is a new query that let you get raw instantlock signatures for one or more transaction hashes. This is useful for creating new Platform Identities in Rust projects.

# What was done
* Added `get_instant_locks` method in the client

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced functionality to retrieve instant lock details for transactions, enabling improved transaction status monitoring and verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->